### PR TITLE
Link accessibility

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -1,10 +1,5 @@
 import React, {Component} from 'react';
-import {
-  Platform,
-  StyleSheet,
-  TouchableWithoutFeedback,
-  View,
-} from 'react-native';
+import {Pressable, View, Platform, StyleSheet} from 'react-native';
 import FitImage from 'react-native-fit-image';
 
 import openUrl from './util/openUrl';
@@ -239,22 +234,23 @@ const renderRules = (Text: Component) => ({
   ),
   // Links
   link: (node, children, parent, styles, onLinkPress) => (
-    <Text
+    <Pressable
+      accessibilityRole={'link'}
       key={node.key}
-      style={styles.link}
       onPress={() => openUrl(node.attributes.href, onLinkPress)}
     >
-      {children}
-    </Text>
+      <Text style={styles.link}>{children}</Text>
+    </Pressable>
   ),
   blocklink: (node, children, parent, styles, onLinkPress) => (
-    <TouchableWithoutFeedback
+    <Pressable
+      accessibilityRole={'link'}
       key={node.key}
       onPress={() => openUrl(node.attributes.href, onLinkPress)}
       style={styles.blocklink}
     >
       <View style={styles.image}>{children}</View>
-    </TouchableWithoutFeedback>
+    </Pressable>
   ),
   // Images
   image: (

--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -155,6 +155,10 @@ export const styles = {
   // Links
   link: {
     textDecorationLine: 'underline',
+    // Hackaround for artificial spacing. The link is rendered inside a `Text` as
+    // a `Pressable` with another `Text` inside. See also:
+    // https://stackoverflow.com/questions/66590167/vertically-align-pressable-inside-a-text-component/66590787
+    marginBottom: -4,
   },
   blocklink: {
     flex: 1,


### PR DESCRIPTION
This makes links usable with a11y (accessibility)/assistive tooling  such as Talkback on Android.
Builds on top of #8, hence said to draft.

Note: a workaround became necessary due to the text node in a view within yet another text node.
A full fix would involve reworking the parser.