### PR TITLE
Update font: Courier -> Courier New

### DIFF
--- a/src/lib/styles.js
+++ b/src/lib/styles.js
@@ -92,7 +92,7 @@ export const styles = {
     borderRadius: 4,
     ...Platform.select({
       ['ios']: {
-        fontFamily: 'Courier',
+        fontFamily: 'Courier New',
       },
       ['android']: {
         fontFamily: 'monospace',
@@ -107,7 +107,7 @@ export const styles = {
     borderRadius: 4,
     ...Platform.select({
       ['ios']: {
-        fontFamily: 'Courier',
+        fontFamily: 'Courier New',
       },
       ['android']: {
         fontFamily: 'monospace',
@@ -122,7 +122,7 @@ export const styles = {
     borderRadius: 4,
     ...Platform.select({
       ['ios']: {
-        fontFamily: 'Courier',
+        fontFamily: 'Courier New',
       },
       ['android']: {
         fontFamily: 'monospace',


### PR DESCRIPTION
With the release of iOS 15, Apple has [deprecated](https://developer.apple.com/fonts/system-fonts/?q=courier) the "Courier" font in favor of "Courier New". 

