### PR TITLE
Remove key from image spread

### DIFF
--- a/src/lib/renderRules.js
+++ b/src/lib/renderRules.js
@@ -275,7 +275,6 @@ const renderRules = (Text) => ({
 
     const imageProps = {
       indicator: true,
-      key: node.key,
       style: styles._VIEW_SAFE_image,
       source: {
         uri: show === true ? src : `${defaultImageHandler}${src}`,
@@ -287,7 +286,7 @@ const renderRules = (Text) => ({
       imageProps.accessibilityLabel = alt;
     }
 
-    return <FitImage {...imageProps} />;
+    return <FitImage key={node.key} {...imageProps} />;
   },
 
   // Text Output


### PR DESCRIPTION
Currently, the key is spread onto `FitImage`. This works, but React doesn't like it and throws an error in development. We can instead move it as a direct prop and the errors go away.

```
Warning: A props object containing a "key" prop is being spread into JSX:
  let props = {key: someKey, indicator: ..., style: ..., source: ...};
  <FitImage {...props} />
React keys must be passed directly to JSX without using spread:
  let props = {indicator: ..., style: ..., source: ...};
  <FitImage key={someKey} {...props} />
    in Markdown (created by MarkdownText)
```