### PR TITLE
Bump markdown-it to ^14

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/RonRadtke/react-native-markdown-display",
   "dependencies": {
     "css-to-react-native": "^3.2.0",
-    "markdown-it": "^13.0.1",
+    "markdown-it": "^14.0.0",
     "prop-types": "^15.7.2",
     "react-native-fit-image": "^1.5.5"
   },


### PR DESCRIPTION
current v13 dep uses Node built-in punycode which Metro/RN can't resolve

@ronradtke/react-native-markdown-display@8.1.0 pins markdown-it: ^13.0.1. markdown-it@13 does
  require('punycode') expecting Node's built-in punycode module. React Native's Metro runtime
  doesn't ship Node built-ins, so bundling fails:
  
  The package at ".../markdown-it@13.0.2/.../markdown-it/lib/index.js"
  attempted to import the Node standard library module "punycode".
  It failed because the native React runtime does not include the Node standard library.

    > 14 | var punycode = require('punycode');

  Import stack:
    markdown-it/lib/index.js
    @ronradtke/react-native-markdown-display/src/index.js

  Cause

  markdown-it@14.0.0 replaced require('punycode') with the userland punycode.js package as a
  declared dep — specifically because Node deprecated the built-in. v14 is API-compatible with v13
  for parser consumers (only internals changed).
  
  Suggested fix

  Bump the dep:

  // package.json
  "dependencies": {
    "markdown-it": "^14.0.0"
  }
  
  Workaround for consumers stuck on the current version: add a Metro resolver alias forcing
  markdown-it to a project-level v14 install.

  Environment

  - @ronradtke/react-native-markdown-display 8.1.0
  - markdown-it 13.0.2 (transitive)
  - Expo 56 / Metro 0.84 / React Native 0.83
  - bun 1.3.14